### PR TITLE
Made percentage generation into separate function & made random with floor include upper bound

### DIFF
--- a/src/generation-logic/data.tsv
+++ b/src/generation-logic/data.tsv
@@ -29,5 +29,5 @@ galeriach handlowych	sklepach budowlanych	cukierniach	pasmanteriach	domach jedno
 8	15	6	20	30	40	50	10	12	16	30	25	2	3																
 wieczornych	porannych	8:00-10:00	10:00-12:00	12:00-12:30	15:00-15:30	ciszy nocnej	21:00-7:00	lunchowych	6:00-9:00	0:00-6:00	szczytu	16:00-20:00	17:30-22:00	7:30-9:30															
 starsze niż 65 lat	starsze niż 60 lat	starsze niż 55 lat	starsze niż 70 lat	młodsze niż 70 lat	urodzone w parzyste dni tygodnia	urodzone w nieparzyste dni tygodnia	mieszkające na wsi	zameldowane na pobyt stały w dzielnicy, w której znajduje się sklep	poruszające się na wózku inwalidzkim	chore na choroby przewlekłe	przyjmujące środki przeciwbólowe	utrzymujące się z zasiłku																	
-10	15	20	25	30	35	40	45	50	55	60	65	70	75	80	85	90													
+-																													
 <$32% x 60>																													

--- a/src/generation-logic/generate.js
+++ b/src/generation-logic/generate.js
@@ -56,7 +56,7 @@ function getRandom(n, data) {
 
 function getRandomRoundedPercentage(step = 5) {
     rnd = Math.random();
-    return PERCENTAGE_MIN + Math.floor(rnd * (PERCENTAGE_MAX - PERCENTAGE_MIN) / step) * step;
+    return PERCENTAGE_MIN + Math.floor(rnd * (PERCENTAGE_MAX + 1 - PERCENTAGE_MIN) / step) * step;
 }
 
 function getQuarantineDecision() {
@@ -66,7 +66,7 @@ function getQuarantineDecision() {
     }
     else {
         rnd = Math.random();
-        const quarantine_days = QUARANTINE_MIN + Math.floor(rnd * (QUARANTINE_MAX - QUARANTINE_MIN));
+        const quarantine_days = QUARANTINE_MIN + Math.floor(rnd * (QUARANTINE_MAX + 1 - QUARANTINE_MIN));
         return "zobowiązane do odbycia kwarantanny przez " + quarantine_days + " dni";
     }
 }

--- a/src/generation-logic/generate.js
+++ b/src/generation-logic/generate.js
@@ -56,7 +56,7 @@ function getRandom(n, data) {
 
 function getRandomRoundedPercentage(step = 5) {
     rnd = Math.random();
-    return PERCENTAGE_MIN + Math.floor(rnd * (PERCENTAGE_MAX + 1 - PERCENTAGE_MIN) / step) * step;
+    return PERCENTAGE_MIN + Math.floor(rnd * (PERCENTAGE_MAX + step - PERCENTAGE_MIN) / step) * step;
 }
 
 function getQuarantineDecision() {

--- a/src/generation-logic/generate.js
+++ b/src/generation-logic/generate.js
@@ -55,18 +55,15 @@ function getRandom(n, data) {
 }
 
 function getRandomRoundedPercentage(step) {
-    let rnd = Math.random();
-    return PERCENTAGE_MIN + Math.floor(rnd * (PERCENTAGE_MAX + step - PERCENTAGE_MIN) / step) * step;
+    return PERCENTAGE_MIN + Math.floor(Math.random() * (PERCENTAGE_MAX + step - PERCENTAGE_MIN) / step) * step;
 }
 
 function getQuarantineDecision() {
-    let rnd = Math.random();
-    if (rnd <= 0.25) {
+    if (Math.random() <= 0.25) {
         return "zwolnione z kwarantanny";
     }
     else {
-        rnd = Math.random();
-        const quarantine_days = QUARANTINE_MIN + Math.floor(rnd * (QUARANTINE_MAX + 1 - QUARANTINE_MIN));
+        const quarantine_days = QUARANTINE_MIN + Math.floor(Math.random() * (QUARANTINE_MAX + 1 - QUARANTINE_MIN));
         return "zobowiązane do odbycia kwarantanny przez " + quarantine_days + " dni";
     }
 }

--- a/src/generation-logic/generate.js
+++ b/src/generation-logic/generate.js
@@ -1,6 +1,9 @@
 import data_path from './data.tsv';
 import { shuffleArray } from '../utils'
 
+const PERCENTAGE_MIN = 10;
+const PERCENTAGE_MAX = 90;
+
 const QUARANTINE_MIN = 7;
 const QUARANTINE_MAX = 14;
 
@@ -51,6 +54,11 @@ function getRandom(n, data) {
     return arr[0];
 }
 
+function getRandomRoundedPercentage(step = 5) {
+    rnd = Math.random();
+    return PERCENTAGE_MIN + Math.floor(rnd * (PERCENTAGE_MAX - PERCENTAGE_MIN) / step) * step;
+}
+
 function getQuarantineDecision() {
     let rnd = Math.random();
     if (rnd <= 0.25) {
@@ -96,7 +104,7 @@ export default function generate() {
     dict[28] = getRandom(28, data);
     dict[29] = getRandom(29, data);
     dict[30] = getRandom(30, data);
-    dict[31] = getRandom(31, data);
+    dict[31] = getRandomRoundedPercentage(5);
     dict[32] = getBusSeatsNumber(dict[31]);
     dict['meta'] = {};
     dict['meta'][7] = (Number(dict[7]) % 10).between(2, 4) ? ['mogą', 'osoby'] : ['może', 'osób'];

--- a/src/generation-logic/generate.js
+++ b/src/generation-logic/generate.js
@@ -54,7 +54,7 @@ function getRandom(n, data) {
     return arr[0];
 }
 
-function getRandomRoundedPercentage(step = 5) {
+function getRandomRoundedPercentage(step) {
     rnd = Math.random();
     return PERCENTAGE_MIN + Math.floor(rnd * (PERCENTAGE_MAX + step - PERCENTAGE_MIN) / step) * step;
 }

--- a/src/generation-logic/generate.js
+++ b/src/generation-logic/generate.js
@@ -55,7 +55,7 @@ function getRandom(n, data) {
 }
 
 function getRandomRoundedPercentage(step) {
-    rnd = Math.random();
+    let rnd = Math.random();
     return PERCENTAGE_MIN + Math.floor(rnd * (PERCENTAGE_MAX + step - PERCENTAGE_MIN) / step) * step;
 }
 


### PR DESCRIPTION
About the former: it's only used in bus seat percentage, but it's more usable as a separate function. Included `step` parameter to allow generating nice rounded percentages only. Also updated `data.tsv` file by reducing the line with percentages to tabs only (exactly like line 7).

About the latter: simply added 1 (or `step` value) to difference in random number generation, as right now e.g. `QUARANTINE_MAX` was never generated (I assumed that 14 was supposed to be included, so I changed the code).